### PR TITLE
qmdiClient: when closing, delete client (#30)

### DIFF
--- a/demos/plugin-demo/pluginmanager.cpp
+++ b/demos/plugin-demo/pluginmanager.cpp
@@ -1207,7 +1207,9 @@ void PluginManager::closeClient() {
             ui->mdiTabWidget->currentWidget()->deleteLater();
         }
     } else {
-        client->closeClient(CloseReason::CloseTab);
+        if (client->closeClient(CloseReason::CloseTab)) {
+            delete client;
+        }
     }
 }
 

--- a/src/qmdiclient.cpp
+++ b/src/qmdiclient.cpp
@@ -200,7 +200,6 @@ bool qmdiClient::closeClient(CloseReason reason) {
         if (auto w = qobject_cast<QWidget *>(o)) {
             w->hide();
         }
-        o->deleteLater();
     }
     return true;
 }

--- a/src/qmdiserver.cpp
+++ b/src/qmdiserver.cpp
@@ -163,7 +163,9 @@ void qmdiServer::tryCloseClient(int i) {
     if (!client) {
         return;
     }
-    client->closeClient(CloseReason::CloseTab);
+    if (client->closeClient(CloseReason::CloseTab)) {
+        delete client;
+    }
 }
 
 /**
@@ -192,16 +194,10 @@ void qmdiServer::tryCloseAllButClient(int i) {
     auto n = getClientsCount();
     auto client = getClient(i);
     for (auto j = 0; j < n; j++) {
-        auto c = getClient(j);
-        if (!c) {
+        if (i == j) {
             continue;
         }
-        if (c == client) {
-            continue;
-        }
-        if (!c->closeClient(CloseReason::CloseTab)) {
-            return;
-        }
+        tryCloseClient(i);
     }
 }
 
@@ -216,18 +212,12 @@ void qmdiServer::tryCloseAllButClient(int i) {
  * \since 0.0.4
  */
 void qmdiServer::tryCloseAllClients(CloseReason reason) {
-    auto c = getClientsCount();
-    for (auto i = 0; i < c; i++) {
-        if (getClientsCount() < 2 && keepSingleClient) {
+    auto const count = getClientsCount();
+    for (auto i = count-1; i >= 0; i--) {
+        if (i == 0 && keepSingleClient) {
             return;
         }
-        auto client = getClient(i);
-        if (!client) {
-            continue;
-        }
-        if (!client->closeClient(reason)) {
-            return;
-        }
+        tryCloseClient(i);
     }
 }
 


### PR DESCRIPTION
The real problem I found was the `o->deleteLater()`. I changed this to `delete o`, which is equivalent to `delete this` - and crashes stopped. I find this hacky, so the caller now deletes it.

I also modified the close others, and close all functions to use existing code.

What happened: the client was deleted (later). Then the tab index was changed, to the deleted client, which caused a dangling pointer. With `delete this`, the deletion is done in synchroneous mode, and it no longer crashes here. This used to work in previous version. I think this broke in Qt 6.10.x, as verions compiled with 6.9 do work.

closes #30